### PR TITLE
Update syntax to the latest rust

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 use interpreter;
 
+#[derive(Debug)]
 pub struct Environment {
     stack: Vec<HashMap<String, Rc<interpreter::LispValue>>>
 }
@@ -23,8 +24,8 @@ impl Environment {
     }
 
     pub fn get(&mut self, key: String) -> Option<Rc<interpreter::LispValue>> {
-        self.stack[self.stack.len() - 1].find_copy(&key)
-            .or(self.stack[0].find_copy(&key))
+        self.stack[self.stack.len() - 1].get(&key).cloned() // find_copy(&key)
+            .or(self.stack[0].get(&key).cloned()) // find_copy(&key))
     }
 
     pub fn put(&mut self, key: String, value: Rc<interpreter::LispValue>) {

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -1,16 +1,18 @@
-use interpreter::{LispValue, EvalResult, Int, Float, Cons, Nil, Bool};
 use std::rc::Rc;
+use std::ops::Deref;
+
+use interpreter::{LispValue, EvalResult};
 
 // add function - exposed as (+) to Lisp
 pub fn add(params: Vec<Rc<LispValue>>) -> EvalResult {
     params.into_iter()
-        .fold(Ok(Int(0)), |a, b| {
+        .fold(Ok(LispValue::Int(0)), |a, b| {
             match a {
                 Ok(acc) => match (acc, b.deref()) {
-                    (Int(r), &Int(a)) => Ok(Int(r + a)),
-                    (Int(r), &Float(a)) => Ok(Float((r as f64) + a)),
-                    (Float(r), &Int(a)) => Ok(Float(r + (a as f64))),
-                    (Float(r), &Float(a)) => Ok(Float(r + a)),
+                    (LispValue::Int(r), &LispValue::Int(a)) => Ok(LispValue::Int(r + a)),
+                    (LispValue::Int(r), &LispValue::Float(a)) => Ok(LispValue::Float((r as f64) + a)),
+                    (LispValue::Float(r), &LispValue::Int(a)) => Ok(LispValue::Float(r + (a as f64))),
+                    (LispValue::Float(r), &LispValue::Float(a)) => Ok(LispValue::Float(r + a)),
                     (_, ref rb) => Err(format!("Wrong type: {}", rb))
                 },
                 Err(e) => Err(e)
@@ -25,8 +27,8 @@ pub fn sub(params: Vec<Rc<LispValue>>) -> EvalResult {
         return Err("Incorrect number of parameters".to_string());
     }
     let initial = match params[0].deref() {
-        &Int(r) => Int(r),
-        &Float(r) => Float(r),
+        &LispValue::Int(r) => LispValue::Int(r),
+        &LispValue::Float(r) => LispValue::Float(r),
         e => return Err(format!("Wrong type: {}", e))
     };
     params.into_iter()
@@ -34,10 +36,10 @@ pub fn sub(params: Vec<Rc<LispValue>>) -> EvalResult {
         .fold(Ok(initial), |a, b| {
             match a {
                 Ok(acc) => match (acc, b.deref()) {
-                    (Int(r), &Int(a)) => Ok(Int(r - a)),
-                    (Int(r), &Float(a)) => Ok(Float((r as f64) - a)),
-                    (Float(r), &Int(a)) => Ok(Float(r - (a as f64))),
-                    (Float(r), &Float(a)) => Ok(Float(r - a)),
+                    (LispValue::Int(r), &LispValue::Int(a)) => Ok(LispValue::Int(r - a)),
+                    (LispValue::Int(r), &LispValue::Float(a)) => Ok(LispValue::Float((r as f64) - a)),
+                    (LispValue::Float(r), &LispValue::Int(a)) => Ok(LispValue::Float(r - (a as f64))),
+                    (LispValue::Float(r), &LispValue::Float(a)) => Ok(LispValue::Float(r - a)),
                     (_, ref rb) => Err(format!("Wrong type: {}", rb))
                 },
                 Err(e) => Err(e)
@@ -49,13 +51,13 @@ pub fn sub(params: Vec<Rc<LispValue>>) -> EvalResult {
 // multiplication function - exposed as (*) to Lisp
 pub fn mul(params: Vec<Rc<LispValue>>) -> EvalResult {
     params.into_iter()
-        .fold(Ok(Int(1)), |a, b| {
+        .fold(Ok(LispValue::Int(1)), |a, b| {
             match a {
                 Ok(acc) => match (acc, b.deref()) {
-                    (Int(r), &Int(a)) => Ok(Int(r * a)),
-                    (Int(r), &Float(a)) => Ok(Float((r as f64) * a)),
-                    (Float(r), &Int(a)) => Ok(Float(r * (a as f64))),
-                    (Float(r), &Float(a)) => Ok(Float(r * a)),
+                    (LispValue::Int(r), &LispValue::Int(a)) => Ok(LispValue::Int(r * a)),
+                    (LispValue::Int(r), &LispValue::Float(a)) => Ok(LispValue::Float((r as f64) * a)),
+                    (LispValue::Float(r), &LispValue::Int(a)) => Ok(LispValue::Float(r * (a as f64))),
+                    (LispValue::Float(r), &LispValue::Float(a)) => Ok(LispValue::Float(r * a)),
                     (_, ref rb) => Err(format!("Wrong type: {}", rb))
                 },
                 Err(e) => Err(e)
@@ -70,8 +72,8 @@ pub fn div(params: Vec<Rc<LispValue>>) -> EvalResult {
         return Err("Incorrect number of parameters".to_string());
     }
     let initial = match params[0].deref() {
-        &Int(r) => Int(r),
-        &Float(r) => Float(r),
+        &LispValue::Int(r) => LispValue::Int(r),
+        &LispValue::Float(r) => LispValue::Float(r),
         e => return Err(format!("Wrong type: {}", e))
     };
     params.into_iter()
@@ -79,10 +81,10 @@ pub fn div(params: Vec<Rc<LispValue>>) -> EvalResult {
         .fold(Ok(initial), |a, b| {
             match a {
                 Ok(acc) => match (acc, b.deref()) {
-                    (Int(r), &Int(a)) => if a == 0 { Err(format!("Division by zero")) } else { Ok(Float(r as f64 / a as f64)) },
-                    (Int(r), &Float(a)) => if a == 0.0 { Err(format!("Division by zero")) } else { Ok(Float((r as f64) / a)) },
-                    (Float(r), &Int(a)) => if a == 0 { Err(format!("Division by zero")) } else { Ok(Float(r / (a as f64))) },
-                    (Float(r), &Float(a)) => if a == 0.0 { Err(format!("Division by zero")) } else { Ok(Float(r / a)) },
+                    (LispValue::Int(r), &LispValue::Int(a)) => if a == 0 { Err(format!("Division by zero")) } else { Ok(LispValue::Float(r as f64 / a as f64)) },
+                    (LispValue::Int(r), &LispValue::Float(a)) => if a == 0.0 { Err(format!("Division by zero")) } else { Ok(LispValue::Float((r as f64) / a)) },
+                    (LispValue::Float(r), &LispValue::Int(a)) => if a == 0 { Err(format!("Division by zero")) } else { Ok(LispValue::Float(r / (a as f64))) },
+                    (LispValue::Float(r), &LispValue::Float(a)) => if a == 0.0 { Err(format!("Division by zero")) } else { Ok(LispValue::Float(r / a)) },
                     (_, ref rb) => Err(format!("Wrong type: {}", rb))
                 },
                 Err(e) => Err(e)
@@ -97,8 +99,8 @@ pub fn car(params: Vec<Rc<LispValue>>) -> EvalResult {
         return Err("Incorrect number of parameters".to_string())
     }
     match params[0].deref() {
-        &Cons(ref car, _) => Ok(car.clone()),
-        &Nil => Err("Cannot take the car of an empty list".to_string()),
+        &LispValue::Cons(ref car, _) => Ok(car.clone()),
+        &LispValue::Nil => Err("Cannot take the car of an empty list".to_string()),
         _ => Err("Cannot take the car of a non-list".to_string())
     }
 }
@@ -109,8 +111,8 @@ pub fn cdr(params: Vec<Rc<LispValue>>) -> EvalResult {
         return Err("Incorrect number of parameters".to_string())
     }
     match params[0].deref() {
-        &Cons(_, ref cdr) => Ok(cdr.clone()),
-        &Nil => Err("Cannot take the cdr of an empty list".to_string()),
+        &LispValue::Cons(_, ref cdr) => Ok(cdr.clone()),
+        &LispValue::Nil => Err("Cannot take the cdr of an empty list".to_string()),
         _ => Err("Cannot take the cdr of a non-list".to_string())
     }
 }
@@ -119,27 +121,27 @@ pub fn cons(params: Vec<Rc<LispValue>>) -> EvalResult {
     if params.len() != 2 {
         return Err("Incorrect number of parameters".to_string())
     }
-    Ok(Rc::new(Cons(params[0].clone(), params[1].clone())))
+    Ok(Rc::new(LispValue::Cons(params[0].clone(), params[1].clone())))
 }
 
 // eq function - exposed as (=) to Lisp.
 pub fn eq(params: Vec<Rc<LispValue>>) -> EvalResult {
     if params.len() == 0 {
-        return Ok(Rc::new(Bool(true)));
+        return Ok(Rc::new(LispValue::Bool(true)));
     }
     let first = params[0].clone();
     let res = params.into_iter()
         .fold(true, |a, b| {
             a && b == first
         });
-    Ok(Rc::new(Bool(res)))
+    Ok(Rc::new(LispValue::Bool(res)))
 }
 
 pub fn display(params: Vec<Rc<LispValue>>) -> EvalResult {
     for ref value in params.iter() {
         println!("{}", value);
     }
-    Ok(Rc::new(Nil))
+    Ok(Rc::new(LispValue::Nil))
 }
 
 // pair function - exposed as (pair?) to Lisp.
@@ -147,9 +149,9 @@ pub fn pair(params: Vec<Rc<LispValue>>) -> EvalResult {
     if params.len() != 1 {
         return Err("Incorrect number of parameters".to_string())
     }
-    if let &Cons(_, _) = params[0].deref() {
-        Ok(Rc::new(Bool(true)))
+    if let &LispValue::Cons(_, _) = params[0].deref() {
+        Ok(Rc::new(LispValue::Bool(true)))
     } else {
-        Ok(Rc::new(Bool(false)))
+        Ok(Rc::new(LispValue::Bool(false)))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,16 @@
 #![feature(if_let)]
 #![feature(while_let)]
 #![feature(globs)]
+#![feature(box_syntax, box_patterns)]
 
-use std::io::stdio;
+// This feature is enabled to use `bench` feature, requires nigthly rust
+#![feature(test)]
+
+use std::io;
+use std::ops::Deref;
+
+use std::io::Write;
+
 use reader::SexpReader;
 use interpreter::Interpreter;
 
@@ -16,12 +24,14 @@ fn main() {
     println!("Rust Lisp interpreter, by Sean Gillespie 2014");
     println!("Licensed under the MIT license");
     println!("Control+D to exit");
-    let mut stdin = stdio::stdin();
+    let mut stdin = io::stdin();
     let mut interpreter = Interpreter::new();
     loop {
         print!("lisp> ");
-        if let Ok(line) = stdin.read_line() {
-            process_line(line, &mut interpreter);
+        io::stdout().flush().ok().expect("Could not flush stdout"); // to print prompt before user input
+        let mut input_line = String::new();
+        if let Ok(n) = stdin.read_line(&mut input_line) {
+            process_line(input_line, &mut interpreter);
         } else {
             println!("\nBye!");
             break;
@@ -32,7 +42,7 @@ fn main() {
 
 fn process_line(input: String, interpreter: &mut Interpreter) {
     let mut reader = SexpReader::new();
-    match reader.parse_str_all(input.as_slice()) {
+    match reader.parse_str_all(input.as_str()) {
         Ok(e) => for (idx, sexp) in e.iter().enumerate() {
             match interpreter.eval(sexp)  {
                 Ok(ref val) => match val.deref() {


### PR DESCRIPTION
(rustc version: rustc 1.20.0-nightly (b2c070787 2017-07-13))

I think, this repo might be useful for newcomers.

These changes are simple update of the syntax to correspond modern/latest rust compiler

### Known issues:
* `^D` doesn't exit the repl

All (50) tests are passed, benchmarking below:

```
test interpreter::tests::bench_addition          ... bench:       3,432 ns/iter (+/- 1,219)
test interpreter::tests::bench_factorial         ... bench:      14,726 ns/iter (+/- 3,665)
test interpreter::tests::bench_fibonacci         ... bench:      24,223 ns/iter (+/- 4,785)
test interpreter::tests::lisp_first_25_squares   ... bench:     212,894 ns/iter (+/- 52,750)
test interpreter::tests::python_first_25_squares ... bench:         544 ns/iter (+/- 239)
test interpreter::tests::ruby_first_25_squares   ... bench:         478 ns/iter (+/- 206)
test interpreter::tests::rust_first_25_squares   ... bench:           3 ns/iter (+/- 1)
```

(MBP Early 2015, 2.7 GHz Intel Core i5)